### PR TITLE
Add simple cyclic voltammetry web simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains a minimal web service that simulates cyclic voltammetry
 ```bash
 python server.py
 ```
+Press `Ctrl-C` in the terminal to stop the server.
 
 The server listens on `http://localhost:8000`. Open this address in a web browser to load `index.html`. Fill out the form parameters and run the simulation. The resulting current vs. potential curve is displayed using Chart.js.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# test
-test for open ai codex
+# Cyclic Voltammetry Simulator
+
+This repository contains a minimal web service that simulates cyclic voltammetry using a Python backend. The simulation uses only Python's standard library.
+
+## Running the server
+
+```bash
+python server.py
+```
+
+The server listens on `http://localhost:8000`. Open this address in a web browser to load `index.html`. Fill out the form parameters and run the simulation. The resulting current vs. potential curve is displayed using Chart.js.
+
+## Files
+
+- `simulation.py` – Implements the cyclic voltammetry simulation.
+- `server.py` – Simple HTTP server that exposes a `/simulate` endpoint and serves `index.html`.
+- `index.html` – Web interface for entering parameters and viewing the graph.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Cyclic Voltammetry Simulation</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<h1>Cyclic Voltammetry Simulator</h1>
+<form id="sim-form">
+    <label>Start Potential (V): <input type="number" name="E_start" step="any" value="-0.5"></label><br>
+    <label>Reverse Potential (V): <input type="number" name="E_reverse" step="any" value="0.5"></label><br>
+    <label>Formal Potential (V): <input type="number" name="E0" step="any" value="0.0"></label><br>
+    <label>Scan Rate (V/s): <input type="number" name="scan_rate" step="any" value="0.1"></label><br>
+    <label>Steps: <input type="number" name="steps" value="200"></label><br>
+    <button type="submit">Run Simulation</button>
+</form>
+<canvas id="cvChart" width="600" height="400"></canvas>
+<script>
+const form = document.getElementById('sim-form');
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(form));
+    for (const k in data) { data[k] = parseFloat(data[k]); }
+    const res = await fetch('/simulate', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(data)
+    });
+    const result = await res.json();
+    const ctx = document.getElementById('cvChart').getContext('2d');
+    new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: result.potential,
+            datasets: [{label: 'Current (A)', data: result.current, borderColor: 'blue', fill: false}]
+        },
+        options: {
+            responsive: false,
+            scales: {
+                x: { type: 'linear', title: { display: true, text: 'Potential (V)' } },
+                y: { title: { display: true, text: 'Current (A)' } }
+            }
+        }
+    });
+});
+</script>
+</body>
+</html>

--- a/server.py
+++ b/server.py
@@ -1,0 +1,38 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import json
+from simulation import simulate_cv
+
+
+class CVHandler(BaseHTTPRequestHandler):
+    def _set_headers(self, status=200, content_type="text/html"):
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.end_headers()
+
+    def do_GET(self):
+        if self.path == '/' or self.path == '/index.html':
+            self._set_headers()
+            with open('index.html', 'rb') as f:
+                self.wfile.write(f.read())
+        else:
+            self.send_error(404)
+
+    def do_POST(self):
+        if self.path == '/simulate':
+            length = int(self.headers.get('Content-Length', 0))
+            body = self.rfile.read(length)
+            try:
+                params = json.loads(body.decode())
+            except Exception:
+                self.send_error(400)
+                return
+            potentials, currents = simulate_cv(**params)
+            self._set_headers(200, 'application/json')
+            self.wfile.write(json.dumps({'potential': potentials,
+                                         'current': currents}).encode())
+        else:
+            self.send_error(404)
+
+
+if __name__ == '__main__':
+    HTTPServer(('0.0.0.0', 8000), CVHandler).serve_forever()

--- a/server.py
+++ b/server.py
@@ -35,4 +35,10 @@ class CVHandler(BaseHTTPRequestHandler):
 
 
 if __name__ == '__main__':
-    HTTPServer(('0.0.0.0', 8000), CVHandler).serve_forever()
+    httpd = HTTPServer(('0.0.0.0', 8000), CVHandler)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.server_close()

--- a/simulation.py
+++ b/simulation.py
@@ -1,0 +1,43 @@
+import math
+
+FARADAY = 96485.33212  # C/mol
+GAS_CONSTANT = 8.314  # J/mol/K
+TEMPERATURE = 298.15  # K
+
+
+def simulate_cv(E_start=-0.5, E_reverse=0.5, E0=0.0, scan_rate=0.1,
+                area=1e-4, diffusion=1e-5, concentration=1e-3,
+                n_electron=1, steps=200):
+    dt = abs(E_reverse - E_start) / scan_rate / (steps / 2)
+    dx = math.sqrt(2.0 * diffusion * dt * 1.1)
+    n_grid = 50
+    c_o = [concentration for _ in range(n_grid)]
+    c_r = [0.0 for _ in range(n_grid)]
+    potentials = []
+    currents = []
+    seq = []
+    half = steps // 2
+    for i in range(half):
+        frac = i / float(half)
+        seq.append(E_start + (E_reverse - E_start) * frac)
+    for i in range(half, steps):
+        frac = (i - half) / float(half)
+        seq.append(E_reverse - (E_reverse - E_start) * frac)
+    for E in seq:
+        ratio = math.exp(n_electron * FARADAY * (E - E0) / (GAS_CONSTANT * TEMPERATURE))
+        c_o[0] = concentration * ratio / (1 + ratio)
+        c_r[0] = concentration - c_o[0]
+        new_o = c_o[:]
+        new_r = c_r[:]
+        factor = diffusion * dt / (dx * dx)
+        for j in range(1, n_grid - 1):
+            new_o[j] = c_o[j] + factor * (c_o[j + 1] - 2 * c_o[j] + c_o[j - 1])
+            new_r[j] = c_r[j] + factor * (c_r[j + 1] - 2 * c_r[j] + c_r[j - 1])
+        new_o[-1] = concentration
+        new_r[-1] = 0.0
+        c_o, c_r = new_o, new_r
+        flux = diffusion * (c_o[1] - c_o[0]) / dx
+        current = n_electron * FARADAY * area * flux
+        potentials.append(E)
+        currents.append(current)
+    return potentials, currents


### PR DESCRIPTION
## Summary
- build a Python CV simulation using only the standard library
- create a basic HTTP server that exposes `/simulate` for JSON requests
- add a browser interface with Chart.js to display the voltammogram
- document how to run the simulation

## Testing
- `python -m py_compile simulation.py server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c7a60f188333b96b9baad2c5fa7c